### PR TITLE
Add basic homepage that explains who we are

### DIFF
--- a/src/webapp/components/JustTextContext.js
+++ b/src/webapp/components/JustTextContext.js
@@ -49,9 +49,9 @@ export default function JustTextContent({
       )}
       {followupRoute && (
         <Button variant="contained" className={classes.text}>
-          <Link className={classes.link} to={followupRoute}>
+          <a target="_blank" rel="noopener noreferrer" href={followupRoute}>
             {followupText || "Click Here"}
-          </Link>
+          </a>
         </Button>
       )}
     </Box>

--- a/src/webapp/pages/Home.js
+++ b/src/webapp/pages/Home.js
@@ -3,5 +3,10 @@ import React from "react";
 import JustTextContent from "../components/JustTextContext";
 
 export default function HomePage() {
-  return <JustTextContent body="Flatbush United" />;
+  return <JustTextContent
+      header="Welcome to Flatbush United Mutual Aid!"
+      body="We're a local mutual aid group, active in Flatbush and surrounding neighborhoods. We aim to build connections and support each other through this crisis in a spirit of solidarity, recognizing that we all have something to offer and we all have something we need."
+      followupRoute="https://join.slack.com/t/flatbushunited/shared_invite/zt-dufw2c79-uSu75pEECMSdzrZesI0r2g"
+      followupText="Join us on slack!"
+  />;
 }

--- a/src/webapp/pages/NeighborhoodFinder.js
+++ b/src/webapp/pages/NeighborhoodFinder.js
@@ -193,7 +193,6 @@ export default function NeighborhoodFinder() {
           <>
             <Typography className={classes.text} variant="body1">
               Error loading. the tech folks know and are working on it.
-              </a>
             </Typography>
             <Divider className={classes.divider} />
             <EmailButton />


### PR DESCRIPTION
We noticed that our original bit.ly slack hyperlink expired today, so I figured it would be good to have a static link that we could send people to (ie, a website) where they could then be linked to slack. This PR creates a _very_ basic homepage that gives a brief description of Flatbush United + links to our new slack invite link:
![image](https://user-images.githubusercontent.com/2678856/80295430-9541de00-8740-11ea-9ca5-073560a777c9.png)

